### PR TITLE
Fix: Окна подтверждения удаления теперь отображаются поверх форм редактирования

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -219,13 +219,3 @@ Your prepared working directory: /tmp/gh-issue-solver-1767549372266
 Proceed.
 
 Run timestamp: 2026-01-04T17:56:14.263Z
-
----
-
-Issue to solve: https://github.com/ideav/orbits/issues/179
-Your prepared branch: issue-179-cad20f4e48d6
-Your prepared working directory: /tmp/gh-issue-solver-1767819125390
-
-Proceed.
-
-Run timestamp: 2026-01-07T20:52:06.912Z


### PR DESCRIPTION
## Описание проблемы

Окна подтверждения удаления сметы и конструкции отображались под их формой редактирования и не были видны пользователю.

## Причина проблемы

Все модальные окна использовали одинаковые значения z-index:
- `.modal-backdrop`: z-index 1040
- `.modal-dialog-custom`: z-index 1050

Когда окно подтверждения удаления открывалось поверх уже открытого окна редактирования сметы или конструкции, оба окна имели одинаковые z-index значения, что приводило к отображению подтверждения на том же слое или позади формы редактирования.

## Решение

Добавлены специфичные CSS-правила для модальных окон подтверждения удаления с увеличенными z-index значениями:

```css
/* Delete confirmation modals should appear above edit forms */
#deleteModalBackdrop,
#deleteEstimateModalBackdrop,
#deleteConstructionModalBackdrop {
    z-index: 1060;
}

#deleteModalBackdrop .modal-dialog-custom,
#deleteEstimateModalBackdrop .modal-dialog-custom,
#deleteConstructionModalBackdrop .modal-dialog-custom {
    z-index: 1070;
}
```

Теперь окна подтверждения удаления всегда отображаются поверх форм редактирования.

## Изменённые файлы

- `templates/projects.html` - добавлены CSS-правила для корректного отображения модальных окон подтверждения удаления

## Тестирование

Рекомендуется протестировать следующие сценарии:
1. Открыть форму редактирования сметы проекта
2. Нажать кнопку удаления строки сметы
3. Убедиться, что окно подтверждения удаления отображается поверх формы редактирования
4. Повторить для формы редактирования конструкций

Fixes #179

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)