### PR TITLE
Fix: Allow '+ Add row' button to display new construction rows (#187)

### DIFF
--- a/projects.js
+++ b/projects.js
@@ -2727,14 +2727,26 @@ function displayConstructionsData() {
 
     tbody.innerHTML = '';
 
-    // Filter out temporary rows with empty construction names
+    // Filter out old temporary rows with empty construction names, but keep the most recent one
+    // This allows users to add new rows and see them immediately
+    const tempRows = constructionsData.filter(item =>
+        item['КонструкцияID'] && item['КонструкцияID'].startsWith('temp_')
+    );
+
+    // Find the most recent temporary row (last one in the array)
+    const mostRecentTempId = tempRows.length > 0 ? tempRows[tempRows.length - 1]['КонструкцияID'] : null;
+
     const validConstructions = constructionsData.filter(item => {
         // Keep all rows that are already saved (have real IDs)
         if (!item['КонструкцияID'] || !item['КонструкцияID'].startsWith('temp_')) {
             return true;
         }
-        // For temporary rows, only keep those with non-empty construction names
-        return item['Конструкция'] && item['Конструкция'].trim() !== '';
+        // For temporary rows, keep those with non-empty construction names
+        if (item['Конструкция'] && item['Конструкция'].trim() !== '') {
+            return true;
+        }
+        // Always keep the most recent temporary row, even if empty (for adding new constructions)
+        return item['КонструкцияID'] === mostRecentTempId;
     });
 
     if (validConstructions.length === 0) {


### PR DESCRIPTION
## Summary

Fixes the '+ Add row' button not working in the Project Constructions modal.

## Problem

When users clicked the '+ Add row' button in the Project Constructions modal, nothing appeared to happen. The button was calling `addConstructionRow()` correctly, but the new empty row was immediately filtered out by the `displayConstructionsData()` function before it could be displayed to the user.

## Root Cause

The `displayConstructionsData()` function had a filter that removed all temporary rows (rows with IDs starting with 'temp_') that had empty construction names. This meant that newly added rows were never visible to users.

## Solution

Modified the filter logic in `displayConstructionsData()` to:
1. Keep all saved rows (rows with real database IDs)
2. Keep all temporary rows with non-empty construction names
3. **Always keep the most recent temporary row, even if empty** - this ensures users can see and interact with newly added rows

## Testing

After this fix:
- Clicking '+ Add row' immediately displays a new empty row
- Users can type a construction name into the empty row
- The row is automatically saved to the database when a name is entered
- Multiple rows can be added sequentially

## Files Changed

- `projects.js`: Updated `displayConstructionsData()` function

Closes #187

🤖 Generated with [Claude Code](https://claude.com/claude-code)