### PR TITLE
Add Product filter to Add Operation form (#191)

### DIFF
--- a/templates/projects.html
+++ b/templates/projects.html
@@ -928,6 +928,13 @@
             </div>
 
             <div class="form-group">
+                <label for="operationProduct">Изделие</label>
+                <select class="form-control-custom" id="operationProduct">
+                    <option value="">Выберите изделие</option>
+                </select>
+            </div>
+
+            <div class="form-group">
                 <label for="operationTemplate">Операция (шаблон)</label>
                 <select class="form-control-custom" id="operationTemplate">
                     <option value="">Выберите операцию</option>


### PR DESCRIPTION
## Summary

Adds a new "Изделие" (Product) dropdown filter to the Add Operation modal, enabling users to filter operation templates by product in addition to Direction and Work Type.

## Problem

The Add Operation form lacked a Product filter, making it difficult for users to find operation templates when they knew which product they were working with. The operation templates data (from report/6041) includes a Product field, but it wasn't being used in the UI.

## Solution

### UI Changes

Added a new "Изделие" dropdown field positioned between the "Шаблонная" checkbox and "Операция (шаблон)" dropdown, exactly as requested in the issue.

**Add Operation Modal:**
```
Направление ▼
Вид работ ▼
☑ Шаблонная
Изделие ▼         ← NEW
Операция (шаблон) ▼
```

### Implementation Details

**1. Product Extraction**
- Created `extractProducts()` function that processes operation templates from report/6041
- Extracts unique product names from the 'Изделие' field
- Stores products in `dictionaries.products` array

**2. Product Dropdown Population**
- Created `populateProductSelect()` function that:
  - Populates the dropdown with unique products
  - Attaches onchange event listener
  - Called during initial dictionary load

**3. Filtering Logic**
- Created `onProductChange()` handler for product selection changes
- Updated `getFilteredOperationTemplates()` to include product matching:
  ```javascript
  const matchesProduct = !product || template['Изделие'] === product;
  ```
- Updated `filterOperationTemplates()` signature to accept product parameter
- All filters combine with AND logic

**4. State Management**
- Added `product: ''` to `lastOperationFilters` state
- Product selection persists when adding multiple operations to the same task
- Product resets when switching to a different task
- Updated `resetOperationFilters()` and `restoreOperationFilters()` accordingly

**5. Modal Behavior**
- Product field shown when creating new operations
- Product field hidden when editing existing operations (like other filters)
- Field properly enabled/disabled along with other filter fields

### Filter Coordination

All four filters work together:
- **Direction** → filters by 'Направление'
- **Work Type** → filters by 'Вид работ' (only for selected direction)
- **Product** → filters by 'Изделие'
- **Шаблонная** → filters templates marked as template operations

**Example filtering scenarios:**
1. Select Product only → shows all operations for that product
2. Select Direction + Product → shows operations matching both
3. Select Direction + Work Type + Product → shows operations matching all three
4. Add Шаблонная checkbox → further filters to template operations only

### Benefits

✅ Easier to find relevant operations when you know the product
✅ Reduces clutter in operation dropdown when many templates exist
✅ Consistent with existing filter pattern (Direction/Work Type)
✅ Product filter is independent - doesn't depend on Direction/Work Type
✅ State persists per task for better UX when adding multiple operations

## Testing Recommendations

1. Open a project and task, click "+ Операция"
2. Verify "Изделие" dropdown appears before "Операция (шаблон)"
3. Select a product → verify operation dropdown shows only matching operations
4. Combine with Direction/Work Type filters → verify AND logic works
5. Add an operation, click "+ Операция" again on same task → verify product persists
6. Click "+ Операция" on different task → verify product resets
7. Edit an existing operation → verify product field is hidden

## Files Changed

- `templates/projects.html`: Added product dropdown HTML
- `projects.js`: Added product extraction, filtering, and state management

Closes #191

🤖 Generated with [Claude Code](https://claude.com/claude-code)