### PR TITLE
Fix work type selection form (#195)

### DIFF
--- a/templates/project.html
+++ b/templates/project.html
@@ -347,7 +347,13 @@
         box-shadow: 0 4px 12px rgba(0,0,0,0.15);
         z-index: 1000;
         min-width: 350px;
-        max-width: 450px;
+        resize: both;
+        overflow: auto;
+    }
+
+    .work-type-selector::-webkit-resizer {
+        background: linear-gradient(135deg, transparent 50%, #ced4da 50%);
+        border-radius: 0 0 4px 0;
     }
 
     .work-type-selector .selector-header {


### PR DESCRIPTION
## Summary
- Remove max-width from work type selection form to display long values properly
- Add CSS resize property for mouse-draggable border resizing
- Store form dimensions in cookies for persistence across sessions
- Remove duplicate "Направление" word in direction dropdown (selectorDirection)
- Swap display order to "Вид работ / Направление" with proper spacing
- Filter out work types already added to the current estimate row from the selection list
- Save work type to database via POST `_m_set/{estimateId}?JSON&t6850={workTypeId}`
- Store the returned `obj` ID for later deletion operations

## Test plan
- [ ] Open a project and navigate to the estimate tab
- [ ] Click the "+" button to open the work type selector
- [ ] Verify the form is resizable by dragging the corner
- [ ] Verify the form width persists after closing and reopening
- [ ] Verify direction dropdown options don't show duplicate "Направление"
- [ ] Verify work types display as "Вид работ / Направление" format
- [ ] Add a work type and verify it's saved to the database
- [ ] Verify added work types are hidden from the selection list

Closes #195

🤖 Generated with [Claude Code](https://claude.com/claude-code)