### PR TITLE
Add XSRF token to all POST requests (#199)

### DIFF
--- a/project.js
+++ b/project.js
@@ -608,7 +608,7 @@ function addSelectedWorkType() {
 
     // Save to server via POST _m_set/{estimateId}?JSON&t6850={workTypeId}
     const estimateId = currentWorkTypeRow;
-    fetch(`https://${window.location.host}/${db}/_m_set/${estimateId}?JSON&t6850=${selectedId}`, {
+    fetch(`https://${window.location.host}/${db}/_m_set/${estimateId}?JSON&t6850=${selectedId}&_xsrf=${xsrf}`, {
         method: 'POST',
         credentials: 'include'
     })
@@ -706,7 +706,7 @@ function updateEstimateField(estimateId, field, value) {
 
     // Save to server if not a new row
     if (!row['isNew'] && apiParam) {
-        fetch(`https://${window.location.host}/${db}/_m_set/${estimateId}?JSON&${apiParam}`, {
+        fetch(`https://${window.location.host}/${db}/_m_set/${estimateId}?JSON&${apiParam}&_xsrf=${xsrf}`, {
             method: 'POST',
             credentials: 'include'
         })
@@ -729,7 +729,7 @@ function handleEstimateNameBlur(estimateId, value) {
 
     // If this is a new row and name is filled, save to DB
     if (row['isNew'] && value && value.trim()) {
-        fetch(`https://${window.location.host}/${db}/_m_new/678?JSON&up=${selectedProject['ПроектID']}&t678=${encodeURIComponent(value)}`, {
+        fetch(`https://${window.location.host}/${db}/_m_new/678?JSON&up=${selectedProject['ПроектID']}&t678=${encodeURIComponent(value)}&_xsrf=${xsrf}`, {
             method: 'POST',
             credentials: 'include'
         })
@@ -769,7 +769,7 @@ function deleteEstimateRowDirect(estimateId) {
     }
 
     // Delete from server
-    fetch(`https://${window.location.host}/${db}/_m_del/${estimateId}?JSON`, {
+    fetch(`https://${window.location.host}/${db}/_m_del/${estimateId}?JSON&_xsrf=${xsrf}`, {
         method: 'POST',
         credentials: 'include'
     })
@@ -954,7 +954,7 @@ function confirmDeleteEstimateRow() {
     }
 
     // Delete from server
-    fetch(`https://${window.location.host}/${db}/_m_del/${estimateId}?JSON`, {
+    fetch(`https://${window.location.host}/${db}/_m_del/${estimateId}?JSON&_xsrf=${xsrf}`, {
         method: 'POST',
         credentials: 'include'
     })


### PR DESCRIPTION
## Summary
Added `_xsrf=${xsrf}` parameter to all data-saving POST requests for CSRF protection:

- `_m_set` for saving work types to estimate rows
- `_m_set` for saving estimate fields (quantity, unit, price)
- `_m_new` for creating new estimate rows
- `_m_del` for deleting estimate rows (both direct and confirmation dialog)

## Test plan
- [ ] Add a new estimate row and verify it saves with XSRF token
- [ ] Edit quantity, unit, and price fields and verify saves include XSRF token
- [ ] Add a work type to estimate row and verify save includes XSRF token
- [ ] Delete an estimate row and verify delete request includes XSRF token
- [ ] Check browser network tab to confirm `_xsrf` parameter is present in all POST requests

Closes #199

🤖 Generated with [Claude Code](https://claude.com/claude-code)