### PR TITLE
Fix work types badges on Estimate tab (#201)

### DIFF
--- a/project.js
+++ b/project.js
@@ -441,6 +441,7 @@ function displayEstimateTable(data) {
                     <div class="work-types-cell" data-estimate-id="${row['СметаID']}">
                         ${workTypesBadges}
                         <button class="add-work-type-btn" onclick="showWorkTypeSelector(event, '${row['СметаID']}')" title="Добавить вид работ">+</button>
+                        ${workTypesIds.length > 0 ? `<button class="clear-work-types-btn" onclick="clearAllWorkTypes('${row['СметаID']}')" title="Удалить все виды работ">×</button>` : ''}
                     </div>
                 </td>
                 <td class="row-actions">
@@ -484,7 +485,6 @@ function renderWorkTypesBadges(workTypeIds, estimateId) {
 
         badges += `<span class="work-type-badge" title="${escapeHtml(workTypeNames)}">
             ${escapeHtml(dirLabel)}/${escapeHtml(workTypeNames)}
-            <span class="remove-btn" onclick="removeWorkType('${estimateId}', '${workTypes.map(w => w['Вид работID']).join(',')}')">&times;</span>
         </span>`;
     });
 
@@ -658,6 +658,32 @@ function removeWorkType(estimateId, workTypeIdsToRemove) {
 
     // Refresh display
     displayEstimateTable(estimateData);
+}
+
+/**
+ * Clear all work types from estimate row
+ */
+function clearAllWorkTypes(estimateId) {
+    const row = estimateData.find(r => r['СметаID'] === estimateId);
+    if (!row) return;
+
+    // Clear work types in local data
+    row['Виды работ'] = '';
+
+    // Send command to clear work types in DB: _m_set/{id}?JSON&t6850=%20
+    fetch(`https://${window.location.host}/${db}/_m_set/${estimateId}?JSON&t6850=%20&_xsrf=${xsrf}`, {
+        method: 'POST',
+        credentials: 'include'
+    })
+    .then(response => response.json())
+    .then(data => {
+        console.log('Cleared all work types:', data);
+        // Refresh display
+        displayEstimateTable(estimateData);
+    })
+    .catch(error => {
+        console.error('Error clearing work types:', error);
+    });
 }
 
 /**

--- a/templates/project.html
+++ b/templates/project.html
@@ -350,6 +350,25 @@
         background: #0056b3;
     }
 
+    .clear-work-types-btn {
+        background: #dc3545;
+        color: white;
+        border: none;
+        border-radius: 50%;
+        width: 22px;
+        height: 22px;
+        cursor: pointer;
+        font-size: 14px;
+        display: inline-flex;
+        align-items: center;
+        justify-content: center;
+        margin-left: 2px;
+    }
+
+    .clear-work-types-btn:hover {
+        background: #c82333;
+    }
+
     /* Work type selector modal */
     .work-type-selector {
         position: absolute;


### PR DESCRIPTION
## Summary
- Remove individual delete buttons (`.remove-btn`) from work type badges
- Add "clear all" button (×) next to the add button (+) for deleting all work types at once
- Button only appears when work types exist in the cell
- Implement `clearAllWorkTypes()` function that sends `POST _m_set/{id}?JSON&t6850=%20&_xsrf=${xsrf}`
- Add CSS styling for the new `.clear-work-types-btn` (red circular button matching the blue add button)

## Test plan
- [ ] Open a project with estimate rows containing work types
- [ ] Verify work type badges no longer have individual × delete buttons
- [ ] Verify a red × button appears next to the blue + button when work types exist
- [ ] Click the red × button and verify all work types are cleared
- [ ] Verify the DB command is sent correctly (check network tab)
- [ ] Verify the red × button disappears when no work types remain

Closes #201

🤖 Generated with [Claude Code](https://claude.com/claude-code)