### PR TITLE
fix(project.js): fix unit dropdown selection and verify estimate field saving

### DIFF
--- a/project.js
+++ b/project.js
@@ -411,9 +411,9 @@ function displayEstimateTable(data) {
         const isNewRow = row['isNew'] && !row['Смета'];
         const hiddenStyle = isNewRow ? 'style="visibility: hidden;"' : '';
 
-        // Build units dropdown options
+        // Build units dropdown options (compare by ID for reliable selection)
         const unitOptions = dictionaries.units.map(u =>
-            `<option value="${u['Ед.изм.ID']}" ${u['Ед.изм.'] === row['Ед.изм.'] ? 'selected' : ''}>${escapeHtml(u['Ед.изм.'])}</option>`
+            `<option value="${u['Ед.изм.ID']}" ${u['Ед.изм.ID'] == row['Ед.изм.ID'] ? 'selected' : ''}>${escapeHtml(u['Ед.изм.'])}</option>`
         ).join('');
 
         return `


### PR DESCRIPTION
## Summary

Fixed unit dropdown selection comparison and verified estimate field saving implementation.

## Changes

- Fixed unit dropdown to compare by ID (`Ед.изм.ID`) instead of name for reliable selection
- Verified all API parameters are correctly implemented:
  - **Quantity (К-во)**: `POST _m_set/{id}?JSON&t1030={value}`
  - **Unit (Ед. изм.)**: `POST _m_set/{id}?JSON&t1036={unit_id}`
  - **Price (Цена)**: `POST _m_set/{id}?JSON&t6456={value}`
- XSRF token is sent via FormData body (fixed in #207)

## Test plan

- [ ] Load estimate data with units
- [ ] Verify correct unit is pre-selected in dropdown
- [ ] Update quantity, unit, price fields
- [ ] Verify correct API calls are made with t1030, t1036, t6456 parameters

Fixes #209

🤖 Generated with [Claude Code](https://claude.com/claude-code)