### PR TITLE
fix(project.js): fix estimate positions filtering in Constructions tab

### DIFF
--- a/project.js
+++ b/project.js
@@ -1055,6 +1055,16 @@ function loadConstructionsData(projectId) {
         constructionsData = constructions || [];
         constructionEstimatePositions = estimatePositions || [];
         constructionProducts = products || [];
+
+        // Debug logging to verify data is loaded
+        console.log('Constructions loaded:', constructionsData.length, 'items');
+        console.log('Estimate positions loaded:', constructionEstimatePositions.length, 'items');
+        console.log('Products loaded:', constructionProducts.length, 'items');
+
+        if (constructionEstimatePositions.length > 0) {
+            console.log('Sample estimate position:', constructionEstimatePositions[0]);
+        }
+
         displayConstructionsTable(constructionsData);
     })
     .catch(error => {
@@ -1088,10 +1098,13 @@ function displayConstructionsTable(data) {
     tbody.innerHTML = sortedData.map((row, index) => {
         const constructionId = row['КонструкцияID'];
 
-        // Get estimate positions for this construction
+        // Get estimate positions for this construction (convert to string for reliable comparison)
         const estimatePositions = constructionEstimatePositions.filter(
-            ep => ep['КонструкцияID'] == constructionId
+            ep => String(ep['КонструкцияID']) === String(constructionId)
         );
+
+        // Debug logging
+        console.log(`Construction ${constructionId}: found ${estimatePositions.length} estimate positions`);
 
         // Build nested estimate positions table
         const estimatePositionsHtml = buildEstimatePositionsTable(estimatePositions);
@@ -1126,9 +1139,9 @@ function buildEstimatePositionsTable(positions) {
     positions.forEach(pos => {
         const estimateId = pos['Смета проектаID'];
 
-        // Get products for this estimate position
+        // Get products for this estimate position (convert to string for reliable comparison)
         const products = constructionProducts.filter(
-            p => p['Смета проектаID'] == estimateId
+            p => String(p['Смета проектаID']) === String(estimateId)
         );
 
         const productsHtml = buildProductsTable(products);


### PR DESCRIPTION
## Summary

Fixed empty nested tables in Constructions tab by improving ID comparison logic.

## Problem

The "Позиция сметы" nested table was showing empty even when data existed, likely due to type mismatches between numeric and string IDs.

## Solution

- Used `String()` conversion for reliable ID comparison between datasets
- Added debug logging to help diagnose data loading and filtering issues

## Changes

```javascript
// Before (loose comparison could fail)
ep => ep['КонструкцияID'] == constructionId

// After (explicit string comparison)
ep => String(ep['КонструкцияID']) === String(constructionId)
```

## Debug Logging Added

- Logs count of loaded constructions, estimate positions, and products
- Logs sample estimate position data for verification
- Logs count of matched estimate positions per construction

## Test plan

- [ ] Open a project with constructions
- [ ] Check browser console for debug logs
- [ ] Verify estimate positions now appear in nested table
- [ ] Verify products appear inside estimate positions

Fixes #215

🤖 Generated with [Claude Code](https://claude.com/claude-code)