### PR TITLE
Fix field name mismatch in estimate positions table

### DIFF
--- a/project.js
+++ b/project.js
@@ -1137,17 +1137,17 @@ function buildEstimatePositionsTable(positions) {
     html += '<tbody>';
 
     positions.forEach(pos => {
-        const estimateId = pos['Смета проектаID'];
+        const estimateId = pos['Позиция сметыID'];
 
         // Get products for this estimate position (convert to string for reliable comparison)
         const products = constructionProducts.filter(
-            p => String(p['Смета проектаID']) === String(estimateId)
+            p => String(p['Позиция сметыID']) === String(estimateId)
         );
 
         const productsHtml = buildProductsTable(products);
 
         html += `<tr>
-            <td>${escapeHtml(pos['Смета проекта'] || '—')}</td>
+            <td>${escapeHtml(pos['Позиция сметы'] || '—')}</td>
             <td>${productsHtml}</td>
         </tr>`;
     });


### PR DESCRIPTION
## Summary
- Fixed field names from `Смета проекта`/`Смета проектаID` to `Позиция сметы`/`Позиция сметыID`
- These field names now match the actual API response from report/7148
- Estimate positions table will now correctly display data

## Root Cause
The debug output showed data was being found (3 estimate positions per construction), but the table appeared empty because the code was looking for `Смета проекта` fields while the API returns `Позиция сметы` fields.

## Test plan
- [ ] Open a project with constructions that have estimate positions
- [ ] Verify the "Позиции сметы" nested table now displays the data
- [ ] Verify products are correctly linked to estimate positions

Fixes #217

🤖 Generated with [Claude Code](https://claude.com/claude-code)