### PR TITLE
Add tooltips to trace product-position mapping

### DIFF
--- a/project.js
+++ b/project.js
@@ -1175,8 +1175,9 @@ function buildFlatConstructionRows(construction, estimatePositions, rowNumber) {
                 isFirstRowOfConstruction = false;
             }
 
-            // Estimate position cell
-            html += `<td class="estimate-cell">${position ? escapeHtml(position['Позиция сметы'] || '—') : '—'}</td>`;
+            // Estimate position cell (with tooltip showing position ID)
+            const posId = position ? (position['Позиция сметыID'] || '?') : '';
+            html += `<td class="estimate-cell" title="Позиция сметыID: ${posId}">${position ? escapeHtml(position['Позиция сметы'] || '—') : '—'}</td>`;
 
             // Empty product cells
             html += '<td class="product-cell">—</td>'.repeat(12);
@@ -1200,14 +1201,17 @@ function buildFlatConstructionRows(construction, estimatePositions, rowNumber) {
                     isFirstRowOfConstruction = false;
                 }
 
-                // Estimate position cell (only on first row of this position)
+                // Estimate position cell (only on first row of this position, with tooltip showing position ID)
                 if (isFirstRowOfPosition) {
-                    html += `<td class="estimate-cell" ${rowCount > 1 ? `rowspan="${rowCount}"` : ''}>${escapeHtml(position['Позиция сметы'] || '—')}</td>`;
+                    const positionId = position['Позиция сметыID'] || '?';
+                    html += `<td class="estimate-cell" title="Позиция сметыID: ${positionId}" ${rowCount > 1 ? `rowspan="${rowCount}"` : ''}>${escapeHtml(position['Позиция сметы'] || '—')}</td>`;
                     isFirstRowOfPosition = false;
                 }
 
                 // Product cells (using field names from API with fallbacks)
-                html += `<td class="product-cell">${escapeHtml(prod['Изделие'] || '—')}</td>`;
+                // First cell (Изделие) has tooltip showing which position this product belongs to
+                const prodPositionId = prod['Позиция сметыID'] || prod['Смета проектаID'] || '?';
+                html += `<td class="product-cell" title="Позиция сметыID: ${prodPositionId}">${escapeHtml(prod['Изделие'] || '—')}</td>`;
                 html += `<td class="product-cell">${escapeHtml(prod['Маркировка'] || '—')}</td>`;
                 html += `<td class="product-cell">${escapeHtml(prod['Документация'] || prod['Документация по изделию'] || prod['Вид документации'] || '—')}</td>`;
                 html += `<td class="product-cell">${escapeHtml(prod['Высота от пола мм'] || '—')}</td>`;


### PR DESCRIPTION
## Summary
Added tooltips (title attributes) to help trace how products are mapped to estimate positions:

- **Estimate position name cell**: hover shows `Позиция сметыID: {id}`
- **Product name (Изделие) cell**: hover shows `Позиция сметыID: {id}`

## How to use
1. Open a project with constructions
2. Go to the Constructions tab
3. Hover over any estimate position name to see its ID
4. Hover over any product name (Изделие) to see which position ID it belongs to
5. Compare the IDs to verify products are correctly matched to positions

## Test plan
- [ ] Hover over estimate position name - tooltip shows position ID
- [ ] Hover over product name - tooltip shows position ID it belongs to
- [ ] Verify matching IDs between positions and their products

Fixes #225

🤖 Generated with [Claude Code](https://claude.com/claude-code)