### PR TITLE
Add small gray ID text to Constructions, estimate positions, and Products

### DIFF
--- a/project.js
+++ b/project.js
@@ -1166,7 +1166,7 @@ function buildFlatConstructionRows(construction, estimatePositions, rowNumber) {
             if (isFirstRowOfConstruction) {
                 const rs = totalRows > 1 ? `rowspan="${totalRows}"` : '';
                 html += `<td class="row-number" ${rs}>${rowNumber}</td>`;
-                html += `<td ${rs}>${escapeHtml(construction['Конструкция'] || '—')}</td>`;
+                html += `<td ${rs}>${escapeHtml(construction['Конструкция'] || '—')}<span class="id-hint">${construction['КонструкцияID']}</span></td>`;
                 html += `<td data-col="doc" ${rs}>${escapeHtml(construction['Документация по конструкции'] || '—')}</td>`;
                 html += `<td data-col="zahvatka" ${rs}>${escapeHtml(construction['Захватка'] || '—')}</td>`;
                 html += `<td data-col="osi" ${rs}>${escapeHtml(construction['Оси'] || '—')}</td>`;
@@ -1177,7 +1177,8 @@ function buildFlatConstructionRows(construction, estimatePositions, rowNumber) {
 
             // Estimate position cell (with tooltip showing position ID)
             const posId = position ? (position['Позиция сметыID'] || '?') : '';
-            html += `<td class="estimate-cell" title="Позиция сметыID: ${posId}">${position ? escapeHtml(position['Позиция сметы'] || '—') : '—'}</td>`;
+            const constructionIdForPos = construction['КонструкцияID'];
+            html += `<td class="estimate-cell" title="Позиция сметыID: ${posId}">${position ? escapeHtml(position['Позиция сметы'] || '—') + `<span class="id-hint">${constructionIdForPos}-${posId}</span>` : '—'}</td>`;
 
             // Empty product cells
             html += '<td class="product-cell">—</td>'.repeat(12);
@@ -1192,7 +1193,7 @@ function buildFlatConstructionRows(construction, estimatePositions, rowNumber) {
                 if (isFirstRowOfConstruction) {
                     const rs = totalRows > 1 ? `rowspan="${totalRows}"` : '';
                     html += `<td class="row-number" ${rs}>${rowNumber}</td>`;
-                    html += `<td ${rs}>${escapeHtml(construction['Конструкция'] || '—')}</td>`;
+                    html += `<td ${rs}>${escapeHtml(construction['Конструкция'] || '—')}<span class="id-hint">${construction['КонструкцияID']}</span></td>`;
                     html += `<td data-col="doc" ${rs}>${escapeHtml(construction['Документация по конструкции'] || '—')}</td>`;
                     html += `<td data-col="zahvatka" ${rs}>${escapeHtml(construction['Захватка'] || '—')}</td>`;
                     html += `<td data-col="osi" ${rs}>${escapeHtml(construction['Оси'] || '—')}</td>`;
@@ -1204,14 +1205,16 @@ function buildFlatConstructionRows(construction, estimatePositions, rowNumber) {
                 // Estimate position cell (only on first row of this position, with tooltip showing position ID)
                 if (isFirstRowOfPosition) {
                     const positionId = position['Позиция сметыID'] || '?';
-                    html += `<td class="estimate-cell" title="Позиция сметыID: ${positionId}" ${rowCount > 1 ? `rowspan="${rowCount}"` : ''}>${escapeHtml(position['Позиция сметы'] || '—')}</td>`;
+                    const constructionIdForPos = construction['КонструкцияID'];
+                    html += `<td class="estimate-cell" title="Позиция сметыID: ${positionId}" ${rowCount > 1 ? `rowspan="${rowCount}"` : ''}>${escapeHtml(position['Позиция сметы'] || '—')}<span class="id-hint">${constructionIdForPos}-${positionId}</span></td>`;
                     isFirstRowOfPosition = false;
                 }
 
                 // Product cells (using field names from API with fallbacks)
                 // First cell (Изделие) has tooltip showing which position this product belongs to
                 const prodPositionId = prod['Позиция сметыID'] || prod['Смета проектаID'] || '?';
-                html += `<td class="product-cell" title="Позиция сметыID: ${prodPositionId}">${escapeHtml(prod['Изделие'] || '—')}</td>`;
+                const prodId = prod['ИзделиеID'] || '?';
+                html += `<td class="product-cell" title="Позиция сметыID: ${prodPositionId}">${escapeHtml(prod['Изделие'] || '—')}<span class="id-hint">${prodPositionId}-${prodId}</span></td>`;
                 html += `<td class="product-cell">${escapeHtml(prod['Маркировка'] || '—')}</td>`;
                 html += `<td class="product-cell">${escapeHtml(prod['Документация'] || prod['Документация по изделию'] || prod['Вид документации'] || '—')}</td>`;
                 html += `<td class="product-cell">${escapeHtml(prod['Высота от пола мм'] || '—')}</td>`;

--- a/templates/project.html
+++ b/templates/project.html
@@ -722,6 +722,14 @@
         display: none !important;
     }
 
+    /* Small gray ID hint text */
+    .id-hint {
+        display: block;
+        font-size: 10px;
+        color: #999;
+        margin-top: 2px;
+    }
+
     /* Delete button styles */
     .btn-delete-row {
         padding: 4px 8px;


### PR DESCRIPTION
## Summary
- Adds small gray text showing IDs next to names in the Constructions table:
  - Constructions: displays КонструкцияID
  - Estimate positions: displays КонструкцияID-Позиция сметыID  
  - Products: displays Позиция сметыID-ИзделиеID

## Test plan
- [ ] Open a project with constructions, estimate positions, and products
- [ ] Verify small gray ID text appears below each name
- [ ] Verify the IDs match the expected format from the issue

Fixes #227

🤖 Generated with [Claude Code](https://claude.com/claude-code)