### PR TITLE
Filter products by both КонструкцияID and Позиция сметыID

### DIFF
--- a/project.js
+++ b/project.js
@@ -1138,12 +1138,15 @@ function buildFlatConstructionRows(construction, estimatePositions, rowNumber) {
         totalRows = 1;
         positionData.push({ position: null, products: [], rowCount: 1 });
     } else {
+        const constructionId = construction['КонструкцияID'];
         estimatePositions.forEach(pos => {
             const estimateId = pos['Позиция сметыID'];
-            // Filter products by estimate position ID (try both possible field names)
+            // Filter products by BOTH construction ID AND estimate position ID
             const products = constructionProducts.filter(p => {
+                const productConstructionId = p['КонструкцияID'];
                 const productPositionId = p['Позиция сметыID'] || p['Смета проектаID'];
-                return String(productPositionId) === String(estimateId);
+                return String(productConstructionId) === String(constructionId) &&
+                       String(productPositionId) === String(estimateId);
             });
             const rowCount = Math.max(1, products.length);
             totalRows += rowCount;


### PR DESCRIPTION
## Summary
- Products are now filtered by BOTH `КонструкцияID` AND `Позиция сметыID`
- Previously products were only filtered by `Позиция сметыID`, which could show products from other constructions

## Test plan
- [ ] Open a project with multiple constructions sharing the same estimate positions
- [ ] Verify products are displayed only for the matching construction and estimate position combination

Fixes #229

🤖 Generated with [Claude Code](https://claude.com/claude-code)