### PR TITLE
Add checkbox columns for selecting Constructions, Estimate positions, and Products

### DIFF
--- a/project.js
+++ b/project.js
@@ -1093,7 +1093,7 @@ function displayConstructionsTable(data) {
     if (!tbody) return;
 
     if (data.length === 0) {
-        tbody.innerHTML = '<tr><td colspan="20" class="no-data-cell">Нет данных о конструкциях</td></tr>';
+        tbody.innerHTML = '<tr><td colspan="23" class="no-data-cell">Нет данных о конструкциях</td></tr>';
         return;
     }
 
@@ -1169,6 +1169,7 @@ function buildFlatConstructionRows(construction, estimatePositions, rowNumber) {
             if (isFirstRowOfConstruction) {
                 const rs = totalRows > 1 ? `rowspan="${totalRows}"` : '';
                 html += `<td class="row-number" ${rs}>${rowNumber}</td>`;
+                html += `<td class="col-checkbox" ${rs}><input type="checkbox" class="compact-checkbox" data-type="construction" data-id="${construction['КонструкцияID']}"></td>`;
                 html += `<td ${rs}>${escapeHtml(construction['Конструкция'] || '—')}<span class="id-hint">${construction['КонструкцияID']}</span></td>`;
                 html += `<td data-col="doc" ${rs}>${escapeHtml(construction['Документация по конструкции'] || '—')}</td>`;
                 html += `<td data-col="zahvatka" ${rs}>${escapeHtml(construction['Захватка'] || '—')}</td>`;
@@ -1178,12 +1179,14 @@ function buildFlatConstructionRows(construction, estimatePositions, rowNumber) {
                 isFirstRowOfConstruction = false;
             }
 
-            // Estimate position cell (with tooltip showing position ID)
+            // Estimate position checkbox and cell (with tooltip showing position ID)
             const posId = position ? (position['Позиция сметыID'] || '?') : '';
             const constructionIdForPos = construction['КонструкцияID'];
+            html += `<td class="col-checkbox"><input type="checkbox" class="compact-checkbox" data-type="estimate" data-id="${posId}" ${position ? '' : 'disabled'}></td>`;
             html += `<td class="estimate-cell" title="Позиция сметыID: ${posId}">${position ? escapeHtml(position['Позиция сметы'] || '—') + `<span class="id-hint">${constructionIdForPos}-${posId}</span>` : '—'}</td>`;
 
-            // Empty product cells
+            // Empty product checkbox and cells
+            html += '<td class="col-checkbox"><input type="checkbox" class="compact-checkbox" data-type="product" disabled></td>';
             html += '<td class="product-cell">—</td>'.repeat(12);
 
             html += '</tr>';
@@ -1196,6 +1199,7 @@ function buildFlatConstructionRows(construction, estimatePositions, rowNumber) {
                 if (isFirstRowOfConstruction) {
                     const rs = totalRows > 1 ? `rowspan="${totalRows}"` : '';
                     html += `<td class="row-number" ${rs}>${rowNumber}</td>`;
+                    html += `<td class="col-checkbox" ${rs}><input type="checkbox" class="compact-checkbox" data-type="construction" data-id="${construction['КонструкцияID']}"></td>`;
                     html += `<td ${rs}>${escapeHtml(construction['Конструкция'] || '—')}<span class="id-hint">${construction['КонструкцияID']}</span></td>`;
                     html += `<td data-col="doc" ${rs}>${escapeHtml(construction['Документация по конструкции'] || '—')}</td>`;
                     html += `<td data-col="zahvatka" ${rs}>${escapeHtml(construction['Захватка'] || '—')}</td>`;
@@ -1205,18 +1209,21 @@ function buildFlatConstructionRows(construction, estimatePositions, rowNumber) {
                     isFirstRowOfConstruction = false;
                 }
 
-                // Estimate position cell (only on first row of this position, with tooltip showing position ID)
+                // Estimate position checkbox and cell (only on first row of this position, with tooltip showing position ID)
                 if (isFirstRowOfPosition) {
                     const positionId = position['Позиция сметыID'] || '?';
                     const constructionIdForPos = construction['КонструкцияID'];
-                    html += `<td class="estimate-cell" title="Позиция сметыID: ${positionId}" ${rowCount > 1 ? `rowspan="${rowCount}"` : ''}>${escapeHtml(position['Позиция сметы'] || '—')}<span class="id-hint">${constructionIdForPos}-${positionId}</span></td>`;
+                    const rsPos = rowCount > 1 ? `rowspan="${rowCount}"` : '';
+                    html += `<td class="col-checkbox" ${rsPos}><input type="checkbox" class="compact-checkbox" data-type="estimate" data-id="${positionId}"></td>`;
+                    html += `<td class="estimate-cell" title="Позиция сметыID: ${positionId}" ${rsPos}>${escapeHtml(position['Позиция сметы'] || '—')}<span class="id-hint">${constructionIdForPos}-${positionId}</span></td>`;
                     isFirstRowOfPosition = false;
                 }
 
-                // Product cells (using field names from API with fallbacks)
+                // Product checkbox and cells (using field names from API with fallbacks)
                 // First cell (Изделие) has tooltip showing which position this product belongs to
                 const prodPositionId = prod['Позиция сметыID'] || prod['Смета проектаID'] || '?';
                 const prodId = prod['ИзделиеID'] || '?';
+                html += `<td class="col-checkbox"><input type="checkbox" class="compact-checkbox" data-type="product" data-id="${prodId}"></td>`;
                 html += `<td class="product-cell" title="Позиция сметыID: ${prodPositionId}">${escapeHtml(prod['Изделие'] || '—')}<span class="id-hint">${prodPositionId}-${prodId}</span></td>`;
                 html += `<td class="product-cell">${escapeHtml(prod['Маркировка'] || '—')}</td>`;
                 html += `<td class="product-cell">${escapeHtml(prod['Документация'] || prod['Документация по изделию'] || prod['Вид документации'] || '—')}</td>`;

--- a/templates/project.html
+++ b/templates/project.html
@@ -464,6 +464,9 @@
 
     .constructions-table th:first-child { width: 40px; text-align: center; }
     .constructions-table th { min-width: 60px; }
+    .constructions-table th.col-checkbox { width: 20px; min-width: 20px; max-width: 20px; padding: 4px 2px; text-align: center; }
+    .constructions-table td.col-checkbox { width: 20px; min-width: 20px; max-width: 20px; padding: 4px 2px; text-align: center; vertical-align: middle; }
+    .constructions-table .compact-checkbox { width: 13px; height: 13px; margin: 0; cursor: pointer; }
     .constructions-table th.col-construction { min-width: 120px; }
     .constructions-table th.col-estimate { min-width: 120px; background-color: #e7f3ff; }
     .constructions-table th.col-product { min-width: 80px; background-color: #fff3cd; }
@@ -880,13 +883,16 @@
                     <thead>
                         <tr>
                             <th>№</th>
+                            <th class="col-checkbox" title="Выбрать конструкцию">☑К</th>
                             <th class="col-construction">Конструкция</th>
                             <th class="col-construction" data-col="doc">Документация</th>
                             <th class="col-construction" data-col="zahvatka">Захватка</th>
                             <th class="col-construction" data-col="osi">Оси</th>
                             <th class="col-construction" data-col="vysotm">Выс.отм.</th>
                             <th class="col-construction" data-col="etazh">Этаж</th>
+                            <th class="col-checkbox" title="Выбрать позицию сметы">☑П</th>
                             <th class="col-estimate">Позиция сметы</th>
+                            <th class="col-checkbox" title="Выбрать изделие">☑И</th>
                             <th class="col-product">Изделие</th>
                             <th class="col-product">Маркировка</th>
                             <th class="col-product">Докум.</th>


### PR DESCRIPTION
## Summary
- Added compact checkbox columns (20px width, 13px checkbox size) for:
  - ☑К - Construction selection (spans all rows)
  - ☑П - Estimate position selection (spans product rows)
  - ☑И - Product selection (one per row)
- Checkboxes are disabled when no data available
- Added `data-type` and `data-id` attributes for programmatic access

## Test plan
- [ ] Open a project with constructions, estimate positions, and products
- [ ] Verify checkbox columns appear with compact styling
- [ ] Verify checkboxes can be checked/unchecked
- [ ] Verify disabled state for empty rows

Fixes #231

🤖 Generated with [Claude Code](https://claude.com/claude-code)