### PR TITLE
Add double-click to add product in selector

### DIFF
--- a/templates/project.html
+++ b/templates/project.html
@@ -1130,7 +1130,7 @@
         <button class="close-selector" onclick="closeProductSelector()">&times;</button>
     </div>
     <input type="text" class="search-input" id="productSelectorSearch" placeholder="Поиск изделия..." oninput="filterProductSelector()">
-    <select id="productSelectorList" size="8" style="height: auto;">
+    <select id="productSelectorList" size="8" style="height: auto;" ondblclick="addSelectedProduct()">
     </select>
     <button type="button" class="btn btn-primary add-btn" onclick="addSelectedProduct()">Добавить</button>
 </div>


### PR DESCRIPTION
## Summary
- Double-clicking on a product in the selector list now triggers the add action
- Same behavior as clicking the "Добавить" button

Fixes #241

🤖 Generated with [Claude Code](https://claude.com/claude-code)