### PR TITLE
Fix XSRF token parameter name (#243)

### DIFF
--- a/project.js
+++ b/project.js
@@ -2012,7 +2012,7 @@ function addSelectedProduct() {
     // Build request body with XSRF token
     let body = `6133=${productId}`;
     if (typeof xsrf !== 'undefined' && xsrf) {
-        body += `&xsrf=${encodeURIComponent(xsrf)}`;
+        body += `&_xsrf=${encodeURIComponent(xsrf)}`;
     }
 
     fetch(url, {


### PR DESCRIPTION
## Summary
- Fixed incorrect XSRF token parameter name in `addSelectedProduct()` function
- Changed `xsrf=` to `_xsrf=` in the POST request body to match server-side validation

## Problem
The `addSelectedProduct()` function in `project.js` was using `xsrf=` as the parameter name when sending the XSRF token, but the server expects `_xsrf=`.

## Solution
Changed line 2015 from:
```javascript
body += `&xsrf=${encodeURIComponent(xsrf)}`;
```
to:
```javascript
body += `&_xsrf=${encodeURIComponent(xsrf)}`;
```

This matches the pattern used in all other POST requests throughout the codebase.

Fixes #243

🤖 Generated with [Claude Code](https://claude.com/claude-code)