### PR TITLE
Fix loadConstructions undefined error (#245)

### DIFF
--- a/project.js
+++ b/project.js
@@ -2028,7 +2028,7 @@ function addSelectedProduct() {
             closeProductSelector();
             // Reload constructions data to refresh the table
             if (selectedProject) {
-                loadConstructions(selectedProject['ПроектID']);
+                loadConstructionsData(selectedProject['ПроектID']);
             }
         } else {
             alert('Ошибка при добавлении изделия');


### PR DESCRIPTION
## Summary
- Fixed `ReferenceError: loadConstructions is not defined` when adding a product

## Problem
The `addSelectedProduct()` function was calling `loadConstructions()` which doesn't exist, causing a ReferenceError when trying to refresh the constructions table after adding a product.

## Solution
Changed `loadConstructions` to `loadConstructionsData` which is the correct function name defined at line 1078.

Fixes #245

🤖 Generated with [Claude Code](https://claude.com/claude-code)