### PR TITLE
Add bulk product addition icon to estimate position header (#247)

### DIFF
--- a/templates/project.html
+++ b/templates/project.html
@@ -842,6 +842,25 @@
         padding: 6px 10px;
         margin-left: 8px;
     }
+
+    /* Bulk add product icon in header */
+    .bulk-add-product-icon {
+        display: none;
+        color: #007bff;
+        cursor: pointer;
+        font-size: 16px;
+        font-weight: bold;
+        margin-left: 6px;
+        vertical-align: middle;
+    }
+
+    .bulk-add-product-icon:hover {
+        color: #0056b3;
+    }
+
+    .bulk-add-product-icon.visible {
+        display: inline;
+    }
 </style>
 
 <div class="project-list-container">
@@ -955,7 +974,7 @@
                             <th class="col-construction" data-col="vysotm">Выс.отм.</th>
                             <th class="col-construction" data-col="etazh">Этаж</th>
                             <th class="col-checkbox" title="Выбрать все позиции сметы"><input type="checkbox" class="compact-checkbox" id="checkAllEstimates" onchange="toggleColumnCheckboxes('estimate', this.checked)"></th>
-                            <th class="col-estimate">Позиция сметы</th>
+                            <th class="col-estimate">Позиция сметы <span id="bulkAddProductIcon" class="bulk-add-product-icon" onclick="showBulkProductSelector(event)" title="Добавить изделие к выбранным позициям">+</span></th>
                             <th class="col-checkbox" title="Выбрать все изделия"><input type="checkbox" class="compact-checkbox" id="checkAllProducts" onchange="toggleColumnCheckboxes('product', this.checked)"></th>
                             <th class="col-product">Изделие</th>
                             <th class="col-product">Маркировка</th>


### PR DESCRIPTION
## Summary
- Added "+" icon in the "Позиция сметы" column header for bulk product addition
- Icon only appears when one or more estimate position checkboxes are checked
- Clicking the icon opens the product selector and adds the selected product to all checked positions

## Changes

### templates/project.html
- Added CSS styles for `.bulk-add-product-icon` (hidden by default, visible when checkboxes are checked)
- Added the icon span element in the "Позиция сметы" header

### project.js
- Modified `toggleColumnCheckboxes()` to update icon visibility when estimate checkboxes change
- Added `updateBulkAddIconVisibility()` - shows/hides icon based on checked estimate checkboxes
- Added `showBulkProductSelector()` - shows product selector for bulk addition
- Modified `addSelectedProduct()` to handle bulk additions
- Added `addProductToMultiplePositions()` - adds product to all selected positions via API
- Added `data-construction-id` attribute to estimate checkboxes for proper product creation
- Added `onchange` handler to checkboxes to update icon visibility

## User Experience
1. User checks one or more estimate position checkboxes
2. "+" icon appears in the "Позиция сметы" header
3. User clicks the icon
4. Product selector appears
5. User selects a product and clicks "Добавить"
6. Product is added to all selected estimate positions
7. Checkboxes are unchecked and icon is hidden
8. Table refreshes to show new products

Fixes #247

🤖 Generated with [Claude Code](https://claude.com/claude-code)