### PR TITLE
Add "+ Конструкция" button above constructions table (#249)

### DIFF
--- a/project.js
+++ b/project.js
@@ -1381,24 +1381,52 @@ function saveConstructionOrder() {
 }
 
 /**
- * Add new construction row
+ * Add new construction row (legacy function)
  */
 function addConstructionRow() {
-    if (!selectedProject) return;
+    promptAddConstruction();
+}
 
-    // TODO: Implement API call to create new construction row
-    console.log('Adding new construction row for project:', selectedProject['ПроектID']);
+/**
+ * Prompt user for construction name and create via API
+ */
+function promptAddConstruction() {
+    if (!selectedProject) {
+        alert('Выберите проект');
+        return;
+    }
 
-    // For now, add a placeholder row
-    const newRow = {
-        'КонструкцияID': 'new_' + Date.now(),
-        'КонструкцияOrder': (constructionsData.length + 1).toString(),
-        'Конструкция': '',
-        'Шаблон': ''
-    };
+    const constructionName = prompt('Введите название конструкции:');
+    if (!constructionName || !constructionName.trim()) {
+        return;
+    }
 
-    constructionsData.push(newRow);
-    displayConstructionsTable(constructionsData);
+    const projectId = selectedProject['ПроектID'];
+    const url = `https://${window.location.host}/${db}/_m_new/6132?JSON&up=${projectId}`;
+
+    const formData = new FormData();
+    formData.append('t6132', constructionName.trim());
+    if (typeof xsrf !== 'undefined' && xsrf) {
+        formData.append('_xsrf', xsrf);
+    }
+
+    fetch(url, {
+        method: 'POST',
+        body: formData
+    })
+    .then(response => response.json())
+    .then(data => {
+        if (data.obj) {
+            // Reload constructions table to show the new row
+            loadConstructionsData(projectId);
+        } else {
+            alert('Ошибка при создании конструкции');
+        }
+    })
+    .catch(error => {
+        console.error('Error creating construction:', error);
+        alert('Ошибка при создании конструкции: ' + error.message);
+    });
 }
 
 /**

--- a/templates/project.html
+++ b/templates/project.html
@@ -861,6 +861,12 @@
     .bulk-add-product-icon.visible {
         display: inline;
     }
+
+    /* Add construction button */
+    .btn-add-construction {
+        white-space: nowrap;
+        margin-right: 15px;
+    }
 </style>
 
 <div class="project-list-container">
@@ -945,8 +951,9 @@
 
         <!-- Constructions Tab Content -->
         <div class="tab-content" id="constructionsTab">
-            <!-- Column visibility controls -->
+            <!-- Controls row with add button and column visibility -->
             <div class="column-controls">
+                <button class="btn btn-primary btn-sm btn-add-construction" onclick="promptAddConstruction()">+&nbsp;Конструкция</button>
                 <span class="column-controls-label">Колонки:</span>
                 <div class="column-toggle-group">
                     <label class="column-toggle-all">


### PR DESCRIPTION
## Summary
- Added "+ Конструкция" button above the constructions table, to the left of column controls
- Button prompts for construction name and creates it via API

## Changes

### templates/project.html
- Added button with `+&nbsp;Конструкция` text (non-breaking space prevents wrapping)
- Added CSS class `.btn-add-construction` with `white-space: nowrap`

### project.js
- Added `promptAddConstruction()` function that:
  - Checks if a project is selected
  - Prompts user for construction name
  - Sends POST request to `_m_new/6132?JSON&up={projectId}`
  - Includes `t6132={name}` and `_xsrf` token
  - Reloads constructions table on success
- Updated `addConstructionRow()` to call `promptAddConstruction()`

## API Details
- Endpoint: `POST _m_new/6132?JSON&up={project_id}`
- Parameters: `t6132={construction_name}`, `_xsrf={xsrf_token}`
- Response: `{ obj: <new_construction_id> }`

Fixes #249

🤖 Generated with [Claude Code](https://claude.com/claude-code)