### PR TITLE
Style bulkAddProductIcon: align right and font-size 20px (#251)

### DIFF
--- a/templates/project.html
+++ b/templates/project.html
@@ -848,9 +848,9 @@
         display: none;
         color: #007bff;
         cursor: pointer;
-        font-size: 16px;
+        font-size: 20px;
         font-weight: bold;
-        margin-left: 6px;
+        float: right;
         vertical-align: middle;
     }
 


### PR DESCRIPTION
## Summary
- Updated styling for the bulk add product icon in the estimate position header

## Changes
- Changed `font-size` from `16px` to `20px`
- Changed `margin-left: 6px` to `float: right` for right alignment

Fixes #251

🤖 Generated with [Claude Code](https://claude.com/claude-code)