### PR TITLE
feat: Display documentation as clickable badges with add icon

### DIFF
--- a/templates/project.html
+++ b/templates/project.html
@@ -646,6 +646,58 @@
         -moz-appearance: textfield;
     }
 
+    /* Documentation links container */
+    .doc-links-container {
+        display: flex;
+        flex-wrap: wrap;
+        gap: 4px;
+        align-items: center;
+    }
+
+    /* Documentation link badge */
+    .doc-link-badge {
+        display: inline-block;
+        padding: 2px 6px;
+        background-color: #e7f3ff;
+        color: #0056b3;
+        border-radius: 3px;
+        font-size: 11px;
+        text-decoration: none;
+        white-space: nowrap;
+        max-width: 100px;
+        overflow: hidden;
+        text-overflow: ellipsis;
+        border: 1px solid #b8daff;
+        transition: background-color 0.2s, border-color 0.2s;
+    }
+
+    .doc-link-badge:hover {
+        background-color: #cce5ff;
+        border-color: #80bdff;
+        text-decoration: none;
+        color: #004085;
+    }
+
+    /* Add documentation icon */
+    .add-doc-icon {
+        display: inline-flex;
+        align-items: center;
+        justify-content: center;
+        width: 18px;
+        height: 18px;
+        color: #adb5bd;
+        cursor: pointer;
+        font-size: 14px;
+        font-weight: bold;
+        border-radius: 50%;
+        transition: color 0.2s, background-color 0.2s;
+    }
+
+    .add-doc-icon:hover {
+        color: #007bff;
+        background-color: #e7f3ff;
+    }
+
     /* Editable construction cells */
     .constructions-table td.construction-cell.editable {
         cursor: pointer;
@@ -1260,6 +1312,25 @@
                 <button type="submit" class="btn btn-primary">Сохранить</button>
             </div>
         </form>
+    </div>
+</div>
+
+<!-- Add Documentation Modal -->
+<div class="modal-backdrop" id="addDocumentationModalBackdrop" onclick="closeAddDocumentationModal()">
+    <div class="modal-dialog-custom" onclick="event.stopPropagation()">
+        <h5>Добавить документацию</h5>
+        <div class="form-group">
+            <label for="docLinkInput">Ссылка на документацию *</label>
+            <input type="url" class="form-control-custom" id="docLinkInput" placeholder="https://example.com/document.pdf" required>
+        </div>
+        <div class="form-group">
+            <label for="docDescriptionInput">Описание (необязательно)</label>
+            <input type="text" class="form-control-custom" id="docDescriptionInput" placeholder="Чертеж, спецификация...">
+        </div>
+        <div class="btn-group-custom">
+            <button type="button" class="btn btn-outline-secondary" onclick="closeAddDocumentationModal()">Отмена</button>
+            <button type="button" class="btn btn-primary" onclick="saveDocumentation()">Сохранить</button>
+        </div>
     </div>
 </div>
 


### PR DESCRIPTION
## Summary

Resolves #268

- Documentation URLs (comma-separated) are now displayed as individual clickable badges that open in new tabs
- Badge text shows compact representation: last 5 characters before the last dot + extension (or last 13 chars if no extension/long extension)
- Added "+" icon in documentation cells to add new documentation links via modal dialog
- Modal allows entering URL (required) and description (optional)
- New documentation is saved via POST `_m_new/6147?JSON&up={parentId}&t6147={link}&t6149={description}`

## Changes

### project.js
- Added `formatLinkText()` - extracts compact display text from URL
- Added `formatDocumentationLinks()` - formats docs as badges + add icon
- Added `showAddDocumentationModal()`, `closeAddDocumentationModal()`, `saveDocumentation()` - modal handlers
- Updated construction documentation rendering (2 places) to use new format
- Updated product documentation rendering to use new format
- Added modal to reset array

### templates/project.html
- Added CSS styles for `.doc-links-container`, `.doc-link-badge`, `.add-doc-icon`
- Added "Add Documentation" modal HTML

## Test plan

- [ ] Verify documentation URLs display as clickable badges
- [ ] Verify badge text shows correct compact format
- [ ] Verify clicking badge opens URL in new tab
- [ ] Verify "+" icon appears in documentation cells
- [ ] Verify modal opens when clicking "+"
- [ ] Verify can add new documentation with URL only
- [ ] Verify can add new documentation with URL and description
- [ ] Verify data reloads after adding documentation

🤖 Generated with [Claude Code](https://claude.com/claude-code)