### PR TITLE
fix: Use correct function name loadConstructionsData

### DIFF
--- a/project.js
+++ b/project.js
@@ -2942,7 +2942,7 @@ function saveDocumentation() {
 
         // Reload the constructions data to show the new documentation
         if (selectedProject) {
-            loadConstructions(selectedProject['ПроектID']);
+            loadConstructionsData(selectedProject['ПроектID']);
         }
     })
     .catch(error => {


### PR DESCRIPTION
## Summary

Fixes #270

Fixed `ReferenceError: loadConstructions is not defined` when saving documentation for products.

## Changes

- Changed `loadConstructions` to `loadConstructionsData` in `saveDocumentation()` function (line 2945)

## Root cause

The function was incorrectly named in PR #269. The correct function name is `loadConstructionsData`, not `loadConstructions`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)