### PR TITLE
fix: decode URL-encoded filenames in documentation badges

### DIFF
--- a/project.js
+++ b/project.js
@@ -2821,6 +2821,13 @@ function formatLinkText(url) {
     // Trim whitespace
     url = url.trim();
 
+    // Decode URL-encoded characters (e.g., %D0%9F -> П for Cyrillic)
+    try {
+        url = decodeURIComponent(url);
+    } catch (e) {
+        // URL might contain invalid encoding, continue with original
+    }
+
     // Find last dot position
     const lastDotIndex = url.lastIndexOf('.');
 


### PR DESCRIPTION
## Summary
- Добавлено декодирование URL-кодирования в функции `formatLinkText()` для отображения читаемых имен файлов в плашках документации

## Изменения
- В `project.js` добавлен вызов `decodeURIComponent()` перед обработкой URL для плашек документации
- Теперь URL-кодированные символы (например, `%D0%9F` → `П` для кириллицы) корректно отображаются

## Test plan
- [ ] Проверить отображение плашек документации с кириллическими именами файлов на странице проекта

Fixes #274

🤖 Generated with [Claude Code](https://claude.com/claude-code)