### PR TITLE
Remove labels 'Направление:' and 'Вид работ:' from operation-name-sub

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -219,16 +219,3 @@ Your prepared working directory: /tmp/gh-issue-solver-1767549372266
 Proceed.
 
 Run timestamp: 2026-01-04T17:56:14.263Z
-
----
-
-Issue to solve: https://github.com/ideav/orbits/issues/289
-Your prepared branch: issue-289-9e8622d83667
-Your prepared working directory: /tmp/gh-issue-solver-1769080053848
-Your forked repository: konard/ideav-orbits
-Original repository (upstream): ideav/orbits
-
-Proceed.
-
-
-Run timestamp: 2026-01-22T11:07:40.213Z


### PR DESCRIPTION
## Summary
This PR removes the labels "Направление:" and "Вид работ:" from the `operation-name-sub` class element in the operations modal, as requested in issue #289.

## Changes Made
- Modified `project.js` line 3640 to remove label prefixes
- Before: `Направление: {directionName} | Вид работ: {workTypeName}`
- After: `{directionName} | {workTypeName}`

## Files Modified
- `project.js` - Updated the operation row template to display only values without labels

## Testing
The change affects the operations modal display where work type information is shown. The direction name and work type name will now be displayed directly without the "Направление:" and "Вид работ:" prefixes.

Fixes #289

---
*This PR was created by the AI issue solver*