### PR TITLE
Fix #369: Limit products in Add Product form based on estimate position

### DIFF
--- a/project.js
+++ b/project.js
@@ -1947,7 +1947,7 @@ function updateBulkAddIconVisibility() {
 /**
  * Show product selector for bulk adding products to selected estimate positions
  */
-function showBulkProductSelector(event) {
+async function showBulkProductSelector(event) {
     event.stopPropagation();
 
     // Get all checked estimate checkboxes
@@ -1969,7 +1969,10 @@ function showBulkProductSelector(event) {
     const selector = document.getElementById('productSelector');
     if (!selector) return;
 
-    populateProductSelector();
+    // For bulk operations, use the first position's ID to fetch allowed products
+    // This provides filtering while keeping complexity reasonable
+    const firstPositionId = currentProductAddContext.positions[0].estimatePositionId;
+    await populateProductSelector(firstPositionId);
 
     // Position selector near the icon
     const rect = event.target.getBoundingClientRect();
@@ -2046,13 +2049,47 @@ function applyProductDetailsVisibility() {
 
 /**
  * Populate the product selector dropdown
+ * @param {string|null} estimatePositionId - Optional estimate position ID to filter products
  */
-function populateProductSelector() {
+async function populateProductSelector(estimatePositionId = null) {
     const select = document.getElementById('productSelectorList');
     if (!select) return;
 
     select.innerHTML = '';
-    allProductsReference.forEach(product => {
+
+    let productsToShow = allProductsReference;
+
+    // If estimate position ID is provided, fetch available products from report/7666
+    if (estimatePositionId) {
+        try {
+            const response = await fetch(`https://${window.location.host}/${db}/report/7666?JSON_KV&FR_SID=${estimatePositionId}`);
+            const data = await response.json();
+
+            // Check if query returned results and extract "Изделие" values
+            if (data && Array.isArray(data) && data.length > 0) {
+                // Extract product names from the "Изделие" field
+                const allowedProductNames = data
+                    .map(item => item['Изделие'])
+                    .filter(name => name && name.trim() !== ''); // Filter out empty values
+
+                // If we have valid product names, filter the products list
+                if (allowedProductNames.length > 0) {
+                    productsToShow = allProductsReference.filter(product => {
+                        const productName = product['Изделие'] || product['Название'] || '';
+                        return allowedProductNames.includes(productName);
+                    });
+                }
+                // If no valid product names found (all empty), show all products (as per requirement)
+            }
+            // If query returned empty result, show all products (as per requirement)
+        } catch (error) {
+            console.error('Error fetching available products:', error);
+            // On error, show all products
+        }
+    }
+
+    // Populate the select with filtered or all products
+    productsToShow.forEach(product => {
         const option = document.createElement('option');
         option.value = product['ИзделиеID'] || product['ID'] || '';
         option.textContent = product['Изделие'] || product['Название'] || 'Без названия';
@@ -2064,7 +2101,7 @@ function populateProductSelector() {
 /**
  * Show the product selector at the click position
  */
-function showProductSelector(event, constructionId, estimatePositionId) {
+async function showProductSelector(event, constructionId, estimatePositionId) {
     event.stopPropagation();
 
     currentProductAddContext = {
@@ -2080,6 +2117,9 @@ function showProductSelector(event, constructionId, estimatePositionId) {
     selector.style.position = 'fixed';
     selector.style.left = `${rect.right + 5}px`;
     selector.style.top = `${rect.top}px`;
+
+    // Populate products with filtering based on estimate position
+    await populateProductSelector(estimatePositionId);
 
     // Reset search and show
     const searchInput = document.getElementById('productSelectorSearch');


### PR DESCRIPTION
## Summary
This PR fixes issue #369 by implementing product filtering in the Add Product form based on the estimate position's work type.

## Changes
- Modified `populateProductSelector()` to accept optional `estimatePositionId` parameter
- When `estimatePositionId` is provided, the function fetches allowed products from `report/7666?JSON_KV&FR_SID={id}`
- Filters the product list based on the 'Изделие' field from the API response
- Shows all products if the query returns empty results or contains empty 'Изделие' values (as per requirement)
- Updated `showProductSelector()` to pass `estimatePositionId` for filtering
- Updated `showBulkProductSelector()` to use the first selected position's ID for filtering

## Behavior
- **Single product add**: Products are filtered based on the specific estimate position
- **Bulk product add**: Products are filtered based on the first selected position (reasonable compromise for UX)
- **Fallback**: If API call fails or returns invalid data, all products are shown

## Testing
The implementation follows the exact requirements from issue #369:
1. Fetches data from `GET: report/7666?JSON_KV&FR_SID={id позиции сметы}`
2. Filters products based on 'Изделие' field
3. Shows all products if query returns empty or contains empty 'Изделие' values

Closes #369